### PR TITLE
Fix Standard and S-N curve menu settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,10 +49,10 @@ elseif ( "${USE_QWTLIB}" STREQUAL "Internal" )
 endif ( "${USE_QWTLIB}" STREQUAL "External" )
 
 #
-# List all subfolders from the fedem foundation repository in this project
+# List all subfolders from the fedem-foundation repository in this project
 #
 
-set ( USE_QT TRUE )
+set ( USE_QT Qt4 )
 set ( USE_VISUALS TRUE )
 set ( USE_VERTEXOBJ TRUE )
 set ( SUBFOLDER_LIST Admin FFaLib FFlLib FFrLib
@@ -75,8 +75,8 @@ if ( WIN )
 
 # Check if the COM-API should be included
 # or if the program should be run with console window
-  option ( USE_COMAPI "Build Fedem with the COM-API" true )
-  option ( NO_CONSOLE_WINDOW "Build fedem without console window" true )
+  option ( USE_COMAPI "Build Fedem with the COM-API" ON )
+  option ( NO_CONSOLE_WINDOW "Build fedem without console window" ON )
   mark_as_advanced ( USE_COMAPI NO_CONSOLE_WINDOW )
 
   if ( USE_COMAPI )

--- a/src/vpmPM/FpModelRDBHandler.C
+++ b/src/vpmPM/FpModelRDBHandler.C
@@ -202,11 +202,11 @@ void FpModelRDBHandler::RDBOpen(FmResultStatusData* rsd,
 
   FFaMsg::setSubTask("Initializing");
 
-  std::string rdbPath, mainRDBPath = rsd->getPath();
+  const std::string& mainRDBPath = rsd->getPath();
   ListUI <<"===> Scanning "<< mainRDBPath <<" for results.\n";
 
   bool noResults = true;
-  std::string listWarning, dialogWarning;
+  std::string rdbPath, listWarning, dialogWarning;
 
   // In batch mode, always ignore found files not present in the RSD
   if (!Fui::hasGUI()) askForMissingInRSD = false;
@@ -484,9 +484,11 @@ void FpModelRDBHandler::RDBClose(FmResultStatusData* currentRSD,
   // Clear the result extractors
   if (clearExtrator) RDBRelease(true);
 
-  // Check if the RDB directory actually exists - nothing to do here if not
-  std::string mainRDBPath = currentRSD->getPath();
-  if (!FpFileSys::verifyDirectory(mainRDBPath,false))
+  // Check if the RDB directory actually exists - nothing to do here if not.
+  // Also return if mainRDBPath is empty, otherwise we will try to clean up
+  // the current working directory.
+  const std::string& mainRDBPath = currentRSD->getPath();
+  if (mainRDBPath.empty() || !FpFileSys::verifyDirectory(mainRDBPath,false))
     return;
 
   if (deleteFilesNotInRSD)
@@ -668,7 +670,7 @@ void FpModelRDBHandler::RDBSave(FmResultStatusData* currentRSD,
 	    <<"\n\ttaskdir\t= "<< currentRSD->getCurrentTaskDirName(true) << std::endl;
 #endif
 
-  std::string mainRDBPath = currentRSD->getPath();
+  const std::string& mainRDBPath = currentRSD->getPath();
   std::string rdbPath = currentRSD->getCurrentTaskDirName(true);
 
   Strings obsoleteFiles;
@@ -1075,7 +1077,6 @@ void FpModelRDBHandler::removeResults(const std::string& rdbResultGroup,
   }
 
   // Get file names for this sub-task
-  std::string filePath = currentRSD->getPath();
   Strings resultFiles, allFiles;
   currentRSD->getAllFileNames(resultFiles,"frs");
   currentRSD->getAllFileNames(allFiles);
@@ -1088,7 +1089,7 @@ void FpModelRDBHandler::removeResults(const std::string& rdbResultGroup,
   remove_result_files(allFiles);
 
   // Delete the directory of the old sub-task, which now should be empty
-  FpFileSys::removeDir(filePath,false);
+  FpFileSys::removeDir(currentRSD->getPath(),false);
 }
 
 

--- a/src/vpmPM/FpPM.C
+++ b/src/vpmPM/FpPM.C
@@ -1185,12 +1185,18 @@ bool FpPM::openTemplateFile(const std::string& modelPath)
   bool writeLogFile = false;
   FFaCmdLineArg::instance()->getValue("logFile",writeLogFile);
   int existingFile = Fedem::loadTemplate(fileName,defaultFile,writeLogFile);
-  if (existingFile < 0) // invalid file path
-    return false;
-  else if (existingFile == 0) // non-existing template file
-    FmDB::newMechanism();
+  if (existingFile < 0) return false; // invalid file path
 
-  FmMechanism* mech = FmDB::getMechanismObject();
+  FmMechanism* mech = NULL;
+  if (existingFile > 0)
+    mech = FmDB::getMechanismObject();
+  else
+  {
+    // Non-existing template file, create an empty mechanism
+    mech = FmDB::newMechanism();
+    mech->syncPath(fileName,true);
+  }
+
   FpPM::saveActivePlugins(mech);
   FpPM::loadPropertyLibraries();
 

--- a/src/vpmUI/vpmUIComponents/FuiSNCurveSelector.C
+++ b/src/vpmUI/vpmUIComponents/FuiSNCurveSelector.C
@@ -22,8 +22,6 @@ void FuiSNCurveSelector::initWidgets()
 						    onStdValueChanged,int));
   this->curveTypeMenu->setOptionSelectedCB(FFaDynCB1M(FuiSNCurveSelector,this,
 						      onCurveValueChanged,int));
-
-  this->populateStdMenu();
 }
 
 
@@ -94,7 +92,10 @@ void FuiSNCurveSelector::getValues(int& stdIdx, int& curveIdx)
 
 void FuiSNCurveSelector::setValues(int stdIdx, int curveIdx)
 {
-  if (stdIdx < 0 || stdIdx >= this->stdTypeMenu->getOptionCount())
+  int numStd = this->stdTypeMenu->getOptionCount();
+  if (numStd < 1) return; // The S-N standard menu has not been populated yet
+
+  if (stdIdx < 0 || stdIdx >= numStd)
   {
     if (FFpSNCurveLib::allocated())
       std::cout <<"Warning: SN-curve library has changed since you last saved your model"
@@ -118,7 +119,7 @@ void FuiSNCurveSelector::setValues(int stdIdx, int curveIdx)
 }
 
 
-void FuiSNCurveSelector::populateStdMenu()
+void FuiSNCurveSelector::onPoppedUpFromMem()
 {
   if (!FFpSNCurveLib::allocated()) return;
 

--- a/src/vpmUI/vpmUIComponents/FuiSNCurveSelector.H
+++ b/src/vpmUI/vpmUIComponents/FuiSNCurveSelector.H
@@ -5,8 +5,8 @@
 // This file is part of FEDEM - https://openfedem.org
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef FUISNCURVESELECTOR_H
-#define FUISNCURVESELECTOR_H
+#ifndef FUI_SN_CURVE_SELECTOR_H
+#define FUI_SN_CURVE_SELECTOR_H
 
 #include "FFuLib/FFuBase/FFuMultUIComponent.H"
 #include "FFaLib/FFaDynCalls/FFaDynCB.H"
@@ -19,7 +19,11 @@ class FFuOptionMenu;
 class FuiSNCurveSelector : virtual public FFuMultUIComponent
 {
 public:
-  FuiSNCurveSelector() {}
+  FuiSNCurveSelector()
+  {
+    stdLabel = curveLabel = NULL;
+    stdTypeMenu = curveTypeMenu = NULL;
+  }
   virtual ~FuiSNCurveSelector() {}
 
   virtual void setSensitivity(bool isSensitive);
@@ -32,11 +36,11 @@ public:
   void getValues(int& stdIdx, int& curveIdx);
   void setValues(int stdIdx, int curveIdx);
 
-  void populateStdMenu();
-
 protected:
   void initWidgets();
+
   virtual void placeWidgets(int width, int height);
+  virtual void onPoppedUpFromMem();
 
 private:
   void onStdValueChanged(int value);


### PR DESCRIPTION
This (i.e., the first commit) fixes a bug introduced in commit 2a8a7b57495516cce1fd7f0dd482939b24052a75 since the GUI widgets now are created before the `sn_curves.fsn` file is loaded.

The second commit prevents that the current working directory is attempted removed when exiting, if no template file was found when starting the model. Probably harmless, as non-empty folder would not be removed, but messages on failure to delete those directories were printed in the console window.

The third commit will set the default model filename (untitled_#.fmm) also when a template file is not found.

The fourth commit is just to use the same version of the fedem-mdb submodule as the qt6-port branch.